### PR TITLE
Use base URL for testnet and production

### DIFF
--- a/main.py
+++ b/main.py
@@ -550,9 +550,9 @@ def init_bot() -> None:
 	global binance_futures_api
 	
 	if IS_TESTNET:
-		binance_futures_api = UMFutures(key=API_KEY_TESTNET, secret=SECRET_KEY_TESTNET)
+		binance_futures_api = UMFutures(key=API_KEY_TESTNET, secret=SECRET_KEY_TESTNET, base_url=URL_BASE_TESTNET)
 	else:
-		binance_futures_api = UMFutures(key=API_KEY_PRODUCTION, secret=SECRET_KEY_PRODUCTION)
+		binance_futures_api = UMFutures(key=API_KEY_PRODUCTION, secret=SECRET_KEY_PRODUCTION, base_url=URL_BASE_PRODUCTION)
 		
 def update_is_price_increasing(
 	price_direction_indicator_name_1: str, 


### PR DESCRIPTION
Hi Erfan!

At this point, unfortunately, the bot is not working. Why?

By default, when the functionality of using testnet was added in pull request #8, it is enabled. Unfortunately, connecting to it was not added and the test keys are used on the default production Binance address.

The commit I propose uses the variables already entered from the `config.py` file when connecting to the Binance API.

This probably solves issue #9 as well.